### PR TITLE
This PR fixes three critical issues when converting large Sqlserver databases to SQLite targets.

### DIFF
--- a/DatabaseInterpreter/DatabaseInterpreter.Core/Interpreter/SqliteInterpreter.cs
+++ b/DatabaseInterpreter/DatabaseInterpreter.Core/Interpreter/SqliteInterpreter.cs
@@ -11,278 +11,282 @@ using System.Threading.Tasks;
 
 namespace DatabaseInterpreter.Core
 {
-    public class SqliteInterpreter : DbInterpreter
+  public class SqliteInterpreter : DbInterpreter
+  {
+    #region Field & Property
+    public override string CommentString => "--";
+    public override string CommandParameterChar => "@";
+    public override string UnicodeLeadingFlag => "";
+    public override bool SupportQuotationChar => true;
+    public override DatabaseType DatabaseType => DatabaseType.Sqlite;
+    public override IndexType IndexType => IndexType.Primary | IndexType.Normal | IndexType.Unique;
+    public override DatabaseObjectType SupportDbObjectType => DatabaseObjectType.Table | DatabaseObjectType.View;
+    public override string DefaultDataType => "TEXT";
+    public override string DefaultSchema => this.ConnectionInfo.Database;
+    public override bool SupportBulkCopy => false;
+    public override bool SupportNchar => false;
+    public override bool SupportTruncateTable => false;
+    public override bool CanInsertIdentityByDefault => true;
+    public override string StringLengthFunctionName => "LENGTH";
+    public override string StringCheckNullFunctionName => "IFNULL";
+    public override string STR_CONCAT_CHARS => "||";
+
+
+    public override char? QuotationLeftChar { get; } = '"';
+    public override char? QuotationRightChar { get; } = '"';
+
+    #endregion
+    #region Constructor
+    public SqliteInterpreter(ConnectionInfo connectionInfo, DbInterpreterOption option) : base(connectionInfo, option)
     {
-        #region Field & Property      
-        public override string CommentString => "--";
-        public override string CommandParameterChar => "@";
-        public override string UnicodeLeadingFlag => "";
-        public override bool SupportQuotationChar => false;
-        public override DatabaseType DatabaseType => DatabaseType.Sqlite;
-        public override IndexType IndexType => IndexType.Primary | IndexType.Normal | IndexType.Unique;
-        public override DatabaseObjectType SupportDbObjectType => DatabaseObjectType.Table | DatabaseObjectType.View;
-        public override string DefaultDataType => "TEXT";
-        public override string DefaultSchema => this.ConnectionInfo.Database;
-        public override bool SupportBulkCopy => false;
-        public override bool SupportNchar => false;
-        public override bool SupportTruncateTable => false;
-        public override bool CanInsertIdentityByDefault => true;
-        public override string StringLengthFunctionName => "LENGTH";
-        public override string StringCheckNullFunctionName => "IFNULL";
-        public override string STR_CONCAT_CHARS => "||";
-        #endregion
+      this.dbConnector = this.GetDbConnector();
+    }
+    #endregion
 
-        #region Constructor
-        public SqliteInterpreter(ConnectionInfo connectionInfo, DbInterpreterOption option) : base(connectionInfo, option)
-        {
-            this.dbConnector = this.GetDbConnector();
-        }
-        #endregion
+    #region Schema Information
 
-        #region Schema Information
+    #region Database & Schema
+    public override async Task<List<Database>> GetDatabasesAsync()
+    {
+      var databases = new List<Database>() { new Database() { Name = this.ConnectionInfo.Database } };
 
-        #region Database & Schema
-        public override async Task<List<Database>> GetDatabasesAsync()
-        {
-            var databases = new List<Database>() { new Database() { Name = this.ConnectionInfo.Database } };
+      return await Task.Run(() => { return databases; });
+    }
 
-            return await Task.Run(() => { return databases; });
-        }
+    public override async Task<List<DatabaseSchema>> GetDatabaseSchemasAsync()
+    {
+      string database = this.ConnectionInfo.Database;
 
-        public override async Task<List<DatabaseSchema>> GetDatabaseSchemasAsync()
-        {
-            string database = this.ConnectionInfo.Database;
+      List<DatabaseSchema> databaseSchemas = new List<DatabaseSchema>() { new DatabaseSchema() { Schema = database, Name = database } };
 
-            List<DatabaseSchema> databaseSchemas = new List<DatabaseSchema>() { new DatabaseSchema() { Schema = database, Name = database } };
+      return await Task.Run(() => { return databaseSchemas; });
+    }
 
-            return await Task.Run(() => { return databaseSchemas; });
-        }
+    public override Task<List<DatabaseSchema>> GetDatabaseSchemasAsync(DbConnection dbConnection)
+    {
+      return this.GetDatabaseSchemasAsync();
+    }
+    #endregion
 
-        public override Task<List<DatabaseSchema>> GetDatabaseSchemasAsync(DbConnection dbConnection)
-        {
-            return this.GetDatabaseSchemasAsync();
-        }
-        #endregion               
+    #region Table
+    public override Task<List<Table>> GetTablesAsync(SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<Table>(this.GetSqlForTables(filter));
+    }
 
-        #region Table
-        public override Task<List<Table>> GetTablesAsync(SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<Table>(this.GetSqlForTables(filter));
-        }
+    public override Task<List<Table>> GetTablesAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<Table>(dbConnection, this.GetSqlForTables(filter));
+    }
 
-        public override Task<List<Table>> GetTablesAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<Table>(dbConnection, this.GetSqlForTables(filter));
-        }
+    private string GetSqlForTables(SchemaInfoFilter filter = null)
+    {
+      return this.GetSqlForTableViews(DatabaseObjectType.Table, filter);
+    }
 
-        private string GetSqlForTables(SchemaInfoFilter filter = null)
-        {
-            return this.GetSqlForTableViews(DatabaseObjectType.Table, filter);
-        }
+    private string GetSqlForTableViews(DatabaseObjectType dbObjectType, SchemaInfoFilter filter = null, bool includeDefinition = false)
+    {
+      SqlBuilder sb = new SqlBuilder();
 
-        private string GetSqlForTableViews(DatabaseObjectType dbObjectType, SchemaInfoFilter filter = null, bool includeDefinition = false)
-        {
-            SqlBuilder sb = new SqlBuilder();
+      string type = dbObjectType.ToString().ToLower();
+      string[] objectNames = null;
+      bool isScriptDbObject = false;
+      bool isSimpleMode = this.IsObjectFectchSimpleMode();
 
-            string type = dbObjectType.ToString().ToLower();
-            string[] objectNames = null;
-            bool isScriptDbObject = false;
-            bool isSimpleMode = this.IsObjectFectchSimpleMode();
+      if (dbObjectType == DatabaseObjectType.Table)
+      {
+        objectNames = filter?.TableNames;
+      }
+      else if (dbObjectType == DatabaseObjectType.View)
+      {
+        objectNames = filter?.ViewNames;
+        isScriptDbObject = true;
+      }
 
-            if (dbObjectType == DatabaseObjectType.Table)
-            {
-                objectNames = filter?.TableNames;
-            }
-            else if (dbObjectType == DatabaseObjectType.View)
-            {
-                objectNames = filter?.ViewNames;
-                isScriptDbObject = true;
-            }
+      string definition = ((isScriptDbObject && !isSimpleMode) || includeDefinition) ? ",sql as Definition" : "";
 
-            string definition = ((isScriptDbObject && !isSimpleMode) || includeDefinition) ? ",sql as Definition" : "";
-
-            sb.Append($@"SELECT name AS Name{definition}                         
+      sb.Append($@"SELECT name AS Name{definition}                         
                         FROM sqlite_schema WHERE type= '{type}' AND name not in('sqlite_sequence')");
 
-            sb.Append(this.GetFilterNamesCondition(filter, objectNames, "name"));
+      sb.Append(this.GetFilterNamesCondition(filter, objectNames, "name"));
 
-            sb.Append("ORDER BY name");
+      sb.Append("ORDER BY name");
 
-            return sb.Content;
-        }
-        #endregion
+      return sb.Content;
+    }
+    #endregion
 
-        #region View
-        public override Task<List<View>> GetViewsAsync(SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<View>(this.GetSqlForViews(filter));
-        }
+    #region View
+    public override Task<List<View>> GetViewsAsync(SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<View>(this.GetSqlForViews(filter));
+    }
 
-        public override Task<List<View>> GetViewsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<View>(dbConnection, this.GetSqlForViews(filter));
-        }
+    public override Task<List<View>> GetViewsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<View>(dbConnection, this.GetSqlForViews(filter));
+    }
 
-        private string GetSqlForViews(SchemaInfoFilter filter = null)
-        {
-            return this.GetSqlForTableViews(DatabaseObjectType.View, filter);
-        }
-        #endregion
+    private string GetSqlForViews(SchemaInfoFilter filter = null)
+    {
+      return this.GetSqlForTableViews(DatabaseObjectType.View, filter);
+    }
+    #endregion
 
-        #region Trigger
-        public override Task<List<TableTrigger>> GetTableTriggersAsync(SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<TableTrigger>(this.GetSqlForTriggers(filter));
-        }
+    #region Trigger
+    public override Task<List<TableTrigger>> GetTableTriggersAsync(SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<TableTrigger>(this.GetSqlForTriggers(filter));
+    }
 
-        public override Task<List<TableTrigger>> GetTableTriggersAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<TableTrigger>(dbConnection, this.GetSqlForTriggers(filter));
-        }
+    public override Task<List<TableTrigger>> GetTableTriggersAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<TableTrigger>(dbConnection, this.GetSqlForTriggers(filter));
+    }
 
-        private string GetSqlForTriggers(SchemaInfoFilter filter = null)
-        {
-            return this.GetSqlForTableChildren(DatabaseObjectType.Trigger, filter);
-        }
+    private string GetSqlForTriggers(SchemaInfoFilter filter = null)
+    {
+      return this.GetSqlForTableChildren(DatabaseObjectType.Trigger, filter);
+    }
 
-        private string GetSqlForTableChildren(DatabaseObjectType dbObjectType, SchemaInfoFilter filter = null)
-        {
-            SqlBuilder sb = new SqlBuilder();
+    private string GetSqlForTableChildren(DatabaseObjectType dbObjectType, SchemaInfoFilter filter = null)
+    {
+      SqlBuilder sb = new SqlBuilder();
 
-            string type = dbObjectType.ToString().ToLower();
-            bool isScriptDbObject = false;
-            bool isSimpleMode = this.IsObjectFectchSimpleMode();
+      string type = dbObjectType.ToString().ToLower();
+      bool isScriptDbObject = false;
+      bool isSimpleMode = this.IsObjectFectchSimpleMode();
 
-            string[] tableNames = filter?.TableNames;
-            string[] childrenNames = null;
+      string[] tableNames = filter?.TableNames;
+      string[] childrenNames = null;
 
 
-            if (dbObjectType == DatabaseObjectType.Trigger)
-            {
-                isScriptDbObject = true;
-                childrenNames = filter?.TableTriggerNames;
-            }
-            else if (dbObjectType == DatabaseObjectType.Column)
-            {
-                childrenNames = filter?.TableTriggerNames;
-            }
+      if (dbObjectType == DatabaseObjectType.Trigger)
+      {
+        isScriptDbObject = true;
+        childrenNames = filter?.TableTriggerNames;
+      }
+      else if (dbObjectType == DatabaseObjectType.Column)
+      {
+        childrenNames = filter?.TableTriggerNames;
+      }
 
-            string definition = isScriptDbObject && !isSimpleMode ? ",sql as Definition" : "";
+      string definition = isScriptDbObject && !isSimpleMode ? ",sql as Definition" : "";
 
-            string unique = dbObjectType == DatabaseObjectType.Index ? ",CASE WHEN INSTR(sql, 'UNIQUE')>0 THEN 1 ELSE 0 END AS IsUnique" : "";
+      string unique = dbObjectType == DatabaseObjectType.Index ? ",CASE WHEN INSTR(sql, 'UNIQUE')>0 THEN 1 ELSE 0 END AS IsUnique" : "";
 
-            sb.Append($@"SELECT name AS Name,tbl_name AS TableName{definition}{unique}                         
+      sb.Append($@"SELECT name AS Name,tbl_name AS TableName{definition}{unique}                         
                         FROM sqlite_schema WHERE type= '{type}'");
 
-            sb.Append(this.GetFilterNamesCondition(filter, tableNames, "tbl_name"));
-            sb.Append(this.GetFilterNamesCondition(filter, childrenNames, "name"));
+      sb.Append(this.GetFilterNamesCondition(filter, tableNames, "tbl_name"));
+      sb.Append(this.GetFilterNamesCondition(filter, childrenNames, "name"));
 
-            if (dbObjectType == DatabaseObjectType.Index)
-            {
-                sb.Append("AND name not like 'sqlite_autoindex%'");
-            }
+      if (dbObjectType == DatabaseObjectType.Index)
+      {
+        sb.Append("AND name not like 'sqlite_autoindex%'");
+      }
 
-            sb.Append("ORDER BY tbl_name,name");
+      sb.Append("ORDER BY tbl_name,name");
 
-            return sb.Content;
-        }
-        #endregion
+      return sb.Content;
+    }
+    #endregion
 
-        #region Column
-        public override Task<List<TableColumn>> GetTableColumnsAsync(SchemaInfoFilter filter = null)
+    #region Column
+    public override Task<List<TableColumn>> GetTableColumnsAsync(SchemaInfoFilter filter = null)
+    {
+      return this.GetTableColumnsAsync(this.CreateConnection(), filter);
+    }
+
+    public override async Task<List<TableColumn>> GetTableColumnsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      bool isForView = this.IsForViewColumnFilter(filter);
+
+      if (filter?.TableNames == null)
+      {
+        if (filter == null)
         {
-            return this.GetTableColumnsAsync(this.CreateConnection(), filter);
-        }
-
-        public override async Task<List<TableColumn>> GetTableColumnsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            bool isForView = this.IsForViewColumnFilter(filter);
-
-            if (filter?.TableNames == null)
-            {
-                if (filter == null)
-                {
-                    filter = new SchemaInfoFilter();
-                }
-
-                if(!isForView)
-                {
-                    filter.TableNames = await this.GetTableNamesAsync();
-                }
-                else
-                {
-                    filter.TableNames = await this.GetViewNamesAsync();
-                }                
-            }
-
-            var columns = await base.GetDbObjectsAsync<TableColumn>(dbConnection, this.GetSqlForTableColumns(filter));
-
-            #region Get generated column expression
-            var tablesSql = this.GetSqlForTableViews(DatabaseObjectType.Table, filter, true);
-
-            var tables = await this.GetDbObjectsAsync<Table>(dbConnection, tablesSql);
-
-            foreach (var table in tables)
-            {
-                string tableName = table.Name;
-                string definition = table.Definition;
-
-                List<List<string>> columnDetails = this.GetTableColumnDetails(definition);
-
-                var tableColumns = columns.Where(item => item.TableName == tableName);
-
-                foreach (var tableColumn in tableColumns)
-                {
-                    foreach (var cd in columnDetails)
-                    {
-                        string name = cd.FirstOrDefault();
-
-                        if (tableColumn.Name == name)
-                        {
-                            for (int i = 0; i < cd.Count; i++)
-                            {
-                                string item = cd[i];
-
-                                if (item.ToUpper() == "GENERATED")
-                                {
-                                    tableColumn.IsGeneratedAlways = true;
-                                    tableColumn.ComputeExp = cd.Skip(i + 1).Where(item => item.ToUpper() != "ALWAYS" && item.ToUpper() != "AS").FirstOrDefault();
-                                    break;
-                                }
-                                else if(item.ToUpper() == "AS")
-                                {
-                                    tableColumn.ComputeExp = cd.Skip(i + 1).FirstOrDefault();
-                                }
-                            }
-
-                            break;
-                        }
-                    }
-                }
-            }
-            #endregion
-
-            return columns;
+          filter = new SchemaInfoFilter();
         }
 
-        private string GetSqlForTableColumns(SchemaInfoFilter filter = null)
+        if (!isForView)
         {
-            SqlBuilder sb = new SqlBuilder();
+          filter.TableNames = await this.GetTableNamesAsync();
+        }
+        else
+        {
+          filter.TableNames = await this.GetViewNamesAsync();
+        }
+      }
 
-            string[] tableNames = filter?.TableNames;
+      var columns = await base.GetDbObjectsAsync<TableColumn>(dbConnection, this.GetSqlForTableColumns(filter));
 
-            if (tableNames != null)
+      #region Get generated column expression
+      var tablesSql = this.GetSqlForTableViews(DatabaseObjectType.Table, filter, true);
+
+      var tables = await this.GetDbObjectsAsync<Table>(dbConnection, tablesSql);
+
+      foreach (var table in tables)
+      {
+        string tableName = table.Name;
+        string definition = table.Definition;
+
+        List<List<string>> columnDetails = this.GetTableColumnDetails(definition);
+
+        var tableColumns = columns.Where(item => item.TableName == tableName);
+
+        foreach (var tableColumn in tableColumns)
+        {
+          foreach (var cd in columnDetails)
+          {
+            string name = cd.FirstOrDefault();
+
+            if (tableColumn.Name == name)
             {
-                for (int i = 0; i < tableNames.Length; i++)
+              for (int i = 0; i < cd.Count; i++)
+              {
+                string item = cd[i];
+
+                if (item.ToUpper() == "GENERATED")
                 {
-                    string tableName = tableNames[i];
+                  tableColumn.IsGeneratedAlways = true;
+                  tableColumn.ComputeExp = cd.Skip(i + 1).Where(item => item.ToUpper() != "ALWAYS" && item.ToUpper() != "AS").FirstOrDefault();
+                  break;
+                }
+                else if (item.ToUpper() == "AS")
+                {
+                  tableColumn.ComputeExp = cd.Skip(i + 1).FirstOrDefault();
+                }
+              }
 
-                    if (i > 0)
-                    {
-                        sb.Append("UNION ALL");
-                    }
+              break;
+            }
+          }
+        }
+      }
+      #endregion
 
-                    sb.Append($@"SELECT name AS Name,'{tableName}' AS TableName,
+      return columns;
+    }
+
+    private string GetSqlForTableColumns(SchemaInfoFilter filter = null)
+    {
+      SqlBuilder sb = new SqlBuilder();
+
+      string[] tableNames = filter?.TableNames;
+
+      if (tableNames != null)
+      {
+        for (int i = 0; i < tableNames.Length; i++)
+        {
+          string tableName = tableNames[i];
+
+          if (i > 0)
+          {
+            sb.Append("UNION ALL");
+          }
+
+          sb.Append($@"SELECT name AS Name,'{tableName}' AS TableName,
                                 type AS DataType,
                                 CASE WHEN INSTR(UPPER(type),'NUMERIC')>=1 AND INSTR(type,'(')>0 THEN CAST(TRIM(SUBSTR(type,INSTR(type,'(')+1,IIF(INSTR(type,',')==0, INSTR(type,')'),INSTR(type,','))-INSTR(type,'(')-1)) AS INTEGER) ELSE NULL END AS Precision,
                                 CASE WHEN INSTR(UPPER(type),'NUMERIC')>=1 AND INSTR(type,',')>0 THEN CAST(TRIM(SUBSTR(type,INSTR(type,',')+1,INSTR(type,')')-INSTR(type,',')-1)) AS INTEGER) ELSE NULL END AS Scale,
@@ -290,872 +294,889 @@ namespace DatabaseInterpreter.Core
                                 CASE WHEN ""notnull""=1 THEN 0 ELSE 1 END AS IsNullable,
                                 dflt_value AS DefaultValue, pk AS IsPrimaryKey, cid AS ""Order""
                                 FROM PRAGMA_TABLE_XINFO('{tableName}')");
-                }
-            }
-
-            return sb.Content;
         }
-        #endregion
+      }
 
-        #region Primary Key
-        public override Task<List<TablePrimaryKeyItem>> GetTablePrimaryKeyItemsAsync(SchemaInfoFilter filter = null)
+      return sb.Content;
+    }
+    #endregion
+
+    #region Primary Key
+    public override Task<List<TablePrimaryKeyItem>> GetTablePrimaryKeyItemsAsync(SchemaInfoFilter filter = null)
+    {
+      return this.GetTablePrimaryKeyItemsAsync(this.CreateConnection(), filter);
+    }
+
+    public override async Task<List<TablePrimaryKeyItem>> GetTablePrimaryKeyItemsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      if (filter?.TableNames == null)
+      {
+        if (filter == null)
         {
-            return this.GetTablePrimaryKeyItemsAsync(this.CreateConnection(), filter);
-        }
-
-        public override async Task<List<TablePrimaryKeyItem>> GetTablePrimaryKeyItemsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            if (filter?.TableNames == null)
-            {
-                if (filter == null)
-                {
-                    filter = new SchemaInfoFilter();
-                }
-
-                filter.TableNames = (await this.GetTableNamesAsync());
-            }
-
-            List<TablePrimaryKeyItem> primaryKeyItems = await base.GetDbObjectsAsync<TablePrimaryKeyItem>(dbConnection, this.GetSqlForPrimaryKeys(filter));
-
-            await this.MakeupTableChildrenNames(primaryKeyItems, filter);
-
-            return primaryKeyItems;
+          filter = new SchemaInfoFilter();
         }
 
-        private string GetSqlForPrimaryKeys(SchemaInfoFilter filter = null)
+        filter.TableNames = (await this.GetTableNamesAsync());
+      }
+
+      List<TablePrimaryKeyItem> primaryKeyItems = await base.GetDbObjectsAsync<TablePrimaryKeyItem>(dbConnection, this.GetSqlForPrimaryKeys(filter));
+
+      await this.MakeupTableChildrenNames(primaryKeyItems, filter);
+
+      return primaryKeyItems;
+    }
+
+    private string GetSqlForPrimaryKeys(SchemaInfoFilter filter = null)
+    {
+      SqlBuilder sb = new SqlBuilder();
+
+      string[] tableNames = filter?.TableNames;
+
+      if (tableNames != null)
+      {
+        for (int i = 0; i < tableNames.Length; i++)
         {
-            SqlBuilder sb = new SqlBuilder();
+          string tableName = tableNames[i];
 
-            string[] tableNames = filter?.TableNames;
+          if (i > 0)
+          {
+            sb.Append("UNION ALL");
+          }
 
-            if (tableNames != null)
-            {
-                for (int i = 0; i < tableNames.Length; i++)
-                {
-                    string tableName = tableNames[i];
-
-                    if (i > 0)
-                    {
-                        sb.Append("UNION ALL");
-                    }
-
-                    sb.Append($@"SELECT '{tableName}' as TableName, name AS ColumnName
+          sb.Append($@"SELECT '{tableName}' as TableName, name AS ColumnName
                         FROM PRAGMA_TABLE_XINFO('{tableName}')
                         WHERE pk>0");
-                }
-            }
-
-            return sb.Content;
         }
+      }
 
-        private async Task MakeupTableChildrenNames(IEnumerable<TableColumnChild> columnChildren, SchemaInfoFilter filter = null)
+      return sb.Content;
+    }
+
+    private async Task MakeupTableChildrenNames(IEnumerable<TableColumnChild> columnChildren, SchemaInfoFilter filter = null)
+    {
+      if (columnChildren == null || columnChildren.Count() == 0)
+      {
+        return;
+      }
+
+      var tablesSql = this.GetSqlForTableViews(DatabaseObjectType.Table, filter, true);
+
+      var tables = await this.GetDbObjectsAsync<Table>(tablesSql);
+
+      foreach (var table in tables)
+      {
+        string tableName = table.Name;
+        string definition = table.Definition;
+
+        List<List<string>> columnDetails = this.GetTableColumnDetails(definition);
+
+        foreach (TableColumnChild cc in columnChildren)
         {
-            if (columnChildren == null || columnChildren.Count() == 0)
+          if (cc.TableName != tableName)
+          {
+            continue;
+          }
+
+          string columnName = cc.ColumnName;
+
+          foreach (List<string> items in columnDetails)
+          {
+            DatabaseObjectType dbObjectType = DbObjectHelper.GetDatabaseObjectType(cc);
+
+            string name = this.ExtractNameFromColumnDefintion(items, dbObjectType);
+
+            if (!string.IsNullOrEmpty(name))
             {
-                return;
-            }
+              string flag = null;
+              int refIndex = items.IndexOf("REFERENCES");
+              bool isForeginKey = false;
 
-            var tablesSql = this.GetSqlForTableViews(DatabaseObjectType.Table, filter, true);
+              if (dbObjectType == DatabaseObjectType.ForeignKey)
+              {
+                flag = "FOREIGN";
+                isForeginKey = true;
+              }
+              else if (dbObjectType == DatabaseObjectType.PrimaryKey)
+              {
+                flag = "PRIMARY";
+              }
 
-            var tables = await this.GetDbObjectsAsync<Table>(tablesSql);
-
-            foreach (var table in tables)
-            {
-                string tableName = table.Name;
-                string definition = table.Definition;
-
-                List<List<string>> columnDetails = this.GetTableColumnDetails(definition);
-
-                foreach (TableColumnChild cc in columnChildren)
+              if (flag != null && items.Any(item => item.ToUpper() == flag))
+              {
+                for (int i = 0; i < items.Count; i++)
                 {
-                    if(cc.TableName != tableName)
+                  if (isForeginKey && i >= refIndex)
+                  {
+                    continue;
+                  }
+
+                  string item = items[i];
+
+                  if (item.StartsWith("(") && item.EndsWith(")"))
+                  {
+                    var columnNames = item.Trim('(', ')').Split(',').Select(item => item.Trim());
+
+                    if (columnNames.Any(item => item.ToLower() == columnName.ToLower()))
                     {
-                        continue;
+                      cc.Name = name;
+                      break;
                     }
-
-                    string columnName = cc.ColumnName;
-
-                    foreach (List<string> items in columnDetails)
-                    {
-                        DatabaseObjectType dbObjectType = DbObjectHelper.GetDatabaseObjectType(cc);
-
-                        string name = this.ExtractNameFromColumnDefintion(items, dbObjectType);
-
-                        if (!string.IsNullOrEmpty(name))
-                        {
-                            string flag = null;
-                            int refIndex = items.IndexOf("REFERENCES");
-                            bool isForeginKey = false;
-
-                            if (dbObjectType == DatabaseObjectType.ForeignKey)
-                            {
-                                flag = "FOREIGN";
-                                isForeginKey = true;
-                            }
-                            else if (dbObjectType == DatabaseObjectType.PrimaryKey)
-                            {
-                                flag = "PRIMARY";
-                            }
-
-                            if (flag != null && items.Any(item => item.ToUpper() == flag))
-                            {
-                                for (int i = 0; i < items.Count; i++)
-                                {
-                                    if(isForeginKey && i>=refIndex)
-                                    {
-                                        continue;
-                                    }
-
-                                    string item = items[i];
-
-                                    if (item.StartsWith("(") && item.EndsWith(")"))
-                                    {
-                                        var columnNames = item.Trim('(', ')').Split(',').Select(item => item.Trim());
-
-                                        if(columnNames.Any(item=>item.ToLower() == columnName.ToLower()))
-                                        {
-                                            cc.Name = name;
-                                            break;
-                                        }
-                                    }
-                                }                                
-                            }
-                        }
-                    }
+                  }
                 }
+              }
             }
+          }
+        }
+      }
+    }
+
+    private async Task<List<DatabaseObject>> GetTableChildren(DatabaseObjectType dbObjectType, DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      List<DatabaseObject> databaseObjects = new List<DatabaseObject>();
+
+      if (dbConnection == null)
+      {
+        dbConnection = this.CreateConnection();
+      }
+
+      var tablesSql = this.GetSqlForTableViews(DatabaseObjectType.Table, filter, true);
+
+      var tables = await this.GetDbObjectsAsync<Table>(dbConnection, tablesSql);
+
+      string flag = "";
+
+      if (dbObjectType == DatabaseObjectType.Index) //unique
+      {
+        flag = "UNIQUE";
+      }
+      else if (dbObjectType == DatabaseObjectType.Constraint) //check constraint
+      {
+        flag = "CHECK";
+      }
+
+      foreach (var table in tables)
+      {
+        string tableName = table.Name;
+        string definition = table.Definition;
+
+        List<List<string>> columns = this.GetTableColumnDetails(definition);
+
+        IEnumerable<List<string>> matchedColumns = columns.Where(item => item.Any(t => t.Trim().ToUpper().StartsWith(flag)));
+
+        foreach (List<string> columnItems in matchedColumns)
+        {
+          bool isTableConstraint = columnItems.First().ToUpper().Trim() == "CONSTRAINT";
+
+          string objName = null;
+          List<string> columNames = new List<string>();
+
+          int index = this.FindIndexInList(columnItems, flag);
+
+          string name = this.ExtractNameFromColumnDefintion(columnItems, dbObjectType);
+
+          if (!string.IsNullOrEmpty(name))
+          {
+            objName = name;
+          }
+
+          if (isTableConstraint)
+          {
+            if (dbObjectType == DatabaseObjectType.Index)
+            {
+              columNames = this.ExtractColumnNamesFromTableConstraint(columnItems, index);
+            }
+          }
+          else
+          {
+            columNames.Add(columnItems.First());
+          }
+
+          if (dbObjectType == DatabaseObjectType.Index) //unique
+          {
+            for (int i = 0; i < columNames.Count; i++)
+            {
+              TableIndexItem tableIndexItem = new TableIndexItem()
+              {
+                Name = objName,
+                ColumnName = columNames[i],
+                TableName = table.Name,
+                Type = "Unique",
+                IsUnique = true,
+                Order = i + 1
+              };
+
+              databaseObjects.Add(tableIndexItem);
+            }
+          }
+          else if (dbObjectType == DatabaseObjectType.Constraint) //check constraint
+          {
+            string columnName = columNames.FirstOrDefault();
+
+            TableConstraint tableConstraint = new TableConstraint()
+            {
+              Name = objName,
+              ColumnName = columnName,
+              TableName = table.Name,
+              Definition = this.ExtractDefinitionFromTableConstraint(columnItems, index)
+            };
+
+            databaseObjects.Add(tableConstraint);
+          }
+        }
+      }
+
+      return databaseObjects;
+    }
+    #endregion
+
+    #region Foreign Key
+    public override Task<List<TableForeignKeyItem>> GetTableForeignKeyItemsAsync(SchemaInfoFilter filter = null, bool isFilterForReferenced = false)
+    {
+      return this.GetTableForeignKeyItemsAsync(this.CreateConnection(), filter, isFilterForReferenced);
+    }
+
+    public override async Task<List<TableForeignKeyItem>> GetTableForeignKeyItemsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null, bool isFilterForReferenced = false)
+    {
+      if (filter?.TableNames == null)
+      {
+        if (filter == null)
+        {
+          filter = new SchemaInfoFilter();
         }
 
-        private async Task<List<DatabaseObject>> GetTableChildren(DatabaseObjectType dbObjectType, DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            List<DatabaseObject> databaseObjects = new List<DatabaseObject>();
+        filter = new SchemaInfoFilter() { TableNames = await GetTableNamesAsync() };
+      }
 
-            if (dbConnection == null)
+      List<TableForeignKeyItem> foreignKeyItems = await base.GetDbObjectsAsync<TableForeignKeyItem>(dbConnection, this.GetSqlForForeignKeys(filter, isFilterForReferenced));
+
+      await this.MakeupTableChildrenNames(foreignKeyItems, filter);
+
+      return foreignKeyItems;
+    }
+
+    private async Task<string[]> GetTableNamesAsync()
+    {
+      var tables = await this.GetTablesAsync();
+
+      return tables.Select(item => item.Name).ToArray();
+    }
+
+    private async Task<string[]> GetViewNamesAsync()
+    {
+      var tables = await this.GetViewsAsync();
+
+      return tables.Select(item => item.Name).ToArray();
+    }
+
+    private string GetSqlForForeignKeys(SchemaInfoFilter filter = null, bool isFilterForReferenced = false)
+    {
+      SqlBuilder sb = new SqlBuilder();
+
+      if (!isFilterForReferenced)
+      {
+        string[] tableNames = filter?.TableNames;
+
+        if (tableNames != null)
+        {
+          for (int i = 0; i < tableNames.Length; i++)
+          {
+            string tableName = tableNames[i];
+
+            if (i > 0)
             {
-                dbConnection = this.CreateConnection();
+              sb.Append("UNION ALL");
             }
 
-            var tablesSql = this.GetSqlForTableViews(DatabaseObjectType.Table, filter, true);
-
-            var tables = await this.GetDbObjectsAsync<Table>(dbConnection, tablesSql);
-
-            string flag = "";
-
-            if (dbObjectType == DatabaseObjectType.Index) //unique
-            {
-                flag = "UNIQUE";
-            }
-            else if (dbObjectType == DatabaseObjectType.Constraint) //check constraint
-            {
-                flag = "CHECK";
-            }
-
-            foreach (var table in tables)
-            {
-                string tableName = table.Name;
-                string definition = table.Definition;
-
-                List<List<string>> columns = this.GetTableColumnDetails(definition);
-
-                IEnumerable<List<string>> matchedColumns = columns.Where(item => item.Any(t => t.Trim().ToUpper().StartsWith(flag)));
-
-                foreach (List<string> columnItems in matchedColumns)
-                {
-                    bool isTableConstraint = columnItems.First().ToUpper().Trim() == "CONSTRAINT";
-
-                    string objName = null;
-                    List<string> columNames = new List<string>();
-
-                    int index = this.FindIndexInList(columnItems, flag);
-
-                    string name = this.ExtractNameFromColumnDefintion(columnItems, dbObjectType);
-
-                    if (!string.IsNullOrEmpty(name))
-                    {
-                        objName = name;
-                    }
-
-                    if (isTableConstraint)
-                    {
-                        if (dbObjectType == DatabaseObjectType.Index)
-                        {
-                            columNames = this.ExtractColumnNamesFromTableConstraint(columnItems, index);
-                        }
-                    }
-                    else
-                    {
-                        columNames.Add(columnItems.First());
-                    }
-
-                    if (dbObjectType == DatabaseObjectType.Index) //unique
-                    {
-                        for (int i = 0; i < columNames.Count; i++)
-                        {
-                            TableIndexItem tableIndexItem = new TableIndexItem()
-                            {
-                                Name = objName,
-                                ColumnName = columNames[i],
-                                TableName = table.Name,
-                                Type = "Unique",
-                                IsUnique = true,
-                                Order = i + 1
-                            };
-
-                            databaseObjects.Add(tableIndexItem);
-                        }
-                    }
-                    else if (dbObjectType == DatabaseObjectType.Constraint) //check constraint
-                    {
-                        string columnName = columNames.FirstOrDefault();
-
-                        TableConstraint tableConstraint = new TableConstraint()
-                        {
-                            Name = objName,
-                            ColumnName = columnName,
-                            TableName = table.Name,
-                            Definition = this.ExtractDefinitionFromTableConstraint(columnItems, index)
-                        };
-
-                        databaseObjects.Add(tableConstraint);
-                    }
-                }
-            }
-
-            return databaseObjects;
-        }
-        #endregion
-
-        #region Foreign Key
-        public override Task<List<TableForeignKeyItem>> GetTableForeignKeyItemsAsync(SchemaInfoFilter filter = null, bool isFilterForReferenced = false)
-        {
-            return this.GetTableForeignKeyItemsAsync(this.CreateConnection(), filter, isFilterForReferenced);
-        }
-
-        public override async Task<List<TableForeignKeyItem>> GetTableForeignKeyItemsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null, bool isFilterForReferenced = false)
-        {
-            if (filter?.TableNames == null)
-            {
-                if (filter == null)
-                {
-                    filter = new SchemaInfoFilter();
-                }
-
-                filter = new SchemaInfoFilter() { TableNames = await GetTableNamesAsync() };
-            }
-
-            List<TableForeignKeyItem> foreignKeyItems = await base.GetDbObjectsAsync<TableForeignKeyItem>(dbConnection, this.GetSqlForForeignKeys(filter, isFilterForReferenced));
-
-            await this.MakeupTableChildrenNames(foreignKeyItems, filter);
-
-            return foreignKeyItems;
-        }
-
-        private async Task<string[]> GetTableNamesAsync()
-        {
-            var tables = await this.GetTablesAsync();
-
-            return tables.Select(item => item.Name).ToArray();
-        }
-
-        private async Task<string[]> GetViewNamesAsync()
-        {
-            var tables = await this.GetViewsAsync();
-
-            return tables.Select(item => item.Name).ToArray();
-        }
-
-        private string GetSqlForForeignKeys(SchemaInfoFilter filter = null, bool isFilterForReferenced = false)
-        {
-            SqlBuilder sb = new SqlBuilder();
-
-            if (!isFilterForReferenced)
-            {
-                string[] tableNames = filter?.TableNames;
-
-                if (tableNames != null)
-                {
-                    for (int i = 0; i < tableNames.Length; i++)
-                    {
-                        string tableName = tableNames[i];
-
-                        if (i > 0)
-                        {
-                            sb.Append("UNION ALL");
-                        }
-
-                        sb.Append($@"SELECT ""table"" AS ReferencedTableName, ""to"" AS ReferencedColumnName,
+            sb.Append($@"SELECT ""table"" AS ReferencedTableName, ""to"" AS ReferencedColumnName,
                                 '{tableName}' AS TableName, ""from"" AS ColumnName,
                                 CASE WHEN on_update='CASCADE' THEN 1 ELSE 0 END AS UpdateCascade,
                                 CASE WHEN on_delete='CASCADE' THEN 1 ELSE 0 END AS DeleteCascade
                                 FROM PRAGMA_foreign_key_list('{tableName}')");
-                    }
-                }
-            }
-
-            return sb.Content;
+          }
         }
-        #endregion
+      }
 
-        #region Index
-        public override Task<List<TableIndexItem>> GetTableIndexItemsAsync(SchemaInfoFilter filter = null, bool includePrimaryKey = false)
+      return sb.Content;
+    }
+    #endregion
+
+    #region Index
+    public override Task<List<TableIndexItem>> GetTableIndexItemsAsync(SchemaInfoFilter filter = null, bool includePrimaryKey = false)
+    {
+      return this.GetTableIndexItemsAsync(this.CreateConnection(), filter);
+    }
+
+    public override async Task<List<TableIndexItem>> GetTableIndexItemsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null, bool includePrimaryKey = false)
+    {
+      var indexes = await base.GetDbObjectsAsync<TableIndex>(dbConnection, this.GetSqlForIndexes(filter));
+
+      indexes.ForEach(item =>
+      {
+        if (item.Type == null)
         {
-            return this.GetTableIndexItemsAsync(this.CreateConnection(), filter);
+          if (item.IsUnique)
+          {
+            item.Type = "Unique";
+          }
+          else
+          {
+            item.Type = "Normal";
+          }
         }
+      });
 
-        public override async Task<List<TableIndexItem>> GetTableIndexItemsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null, bool includePrimaryKey = false)
+      List<TableIndexItem> items = new List<TableIndexItem>();
+
+      var indexColumns = await base.GetDbObjectsAsync<TableIndexItem>(this.GetSqlForIndexColumns(indexes));
+
+      foreach (var ic in indexColumns)
+      {
+        var index = indexes.FirstOrDefault(item => item.Name == ic.Name);
+
+        if (index != null)
         {
-            var indexes = await base.GetDbObjectsAsync<TableIndex>(dbConnection, this.GetSqlForIndexes(filter));
+          ic.TableName = index.TableName;
+          ic.IsUnique = index.IsUnique;
+          ic.IsPrimary = index.IsPrimary;
+        }
+      }
 
-            indexes.ForEach(item =>
-            {
-                if (item.Type == null)
-                {
-                    if (item.IsUnique)
-                    {
-                        item.Type = "Unique";
-                    }
-                    else
-                    {
-                        item.Type = "Normal";
-                    }
-                }
-            });
+      items.AddRange(indexColumns);
 
-            List<TableIndexItem> items = new List<TableIndexItem>();
+      var uniqueIndexes = await this.GetTableChildren(DatabaseObjectType.Index, null, filter);
 
-            var indexColumns = await base.GetDbObjectsAsync<TableIndexItem>(this.GetSqlForIndexColumns(indexes));
+      List<TableIndexItem> uniqueItems = new List<TableIndexItem>();
 
-            foreach (var ic in indexColumns)
-            {
-                var index = indexes.FirstOrDefault(item => item.Name == ic.Name);
-
-                if (index != null)
-                {
-                    ic.TableName = index.TableName;
-                    ic.IsUnique = index.IsUnique;
-                    ic.IsPrimary = index.IsPrimary;
-                }
-            }
-
-            items.AddRange(indexColumns);
-
-            var uniqueIndexes = await this.GetTableChildren(DatabaseObjectType.Index, null, filter);
-
-            List<TableIndexItem> uniqueItems = new List<TableIndexItem>();
-
-            foreach (var unique in uniqueIndexes)
-            {
-                if (!string.IsNullOrEmpty(unique.Name) && items.Any(item => item.TableName == (unique as TableIndexItem).TableName && item.Name == unique.Name))
-                {
-                    continue;
-                }
-
-                uniqueItems.Add(unique as TableIndexItem);
-            }
-
-            items.AddRange(uniqueItems);
-
-            return items;
+      foreach (var unique in uniqueIndexes)
+      {
+        if (!string.IsNullOrEmpty(unique.Name) && items.Any(item => item.TableName == (unique as TableIndexItem).TableName && item.Name == unique.Name))
+        {
+          continue;
         }
 
-        private string GetSqlForIndexes(SchemaInfoFilter filter = null)
+        uniqueItems.Add(unique as TableIndexItem);
+      }
+
+      items.AddRange(uniqueItems);
+
+      return items;
+    }
+
+    private string GetSqlForIndexes(SchemaInfoFilter filter = null)
+    {
+      return this.GetSqlForTableChildren(DatabaseObjectType.Index, filter);
+    }
+
+    private string GetSqlForIndexColumns(List<TableIndex> indexes)
+    {
+      SqlBuilder sb = new SqlBuilder();
+
+      int i = 0;
+
+      foreach (var item in indexes)
+      {
+        if (i > 0)
         {
-            return this.GetSqlForTableChildren(DatabaseObjectType.Index, filter);
+          sb.Append("UNION ALL");
         }
 
-        private string GetSqlForIndexColumns(List<TableIndex> indexes)
+        sb.Append($"SELECT '{item.Name}' AS Name, name AS ColumnName FROM PRAGMA_INDEX_INFO('{item.Name}')");
+
+        i++;
+      }
+
+      return sb.Content;
+    }
+    #endregion
+
+    #region Constraint
+    public override Task<List<TableConstraint>> GetTableConstraintsAsync(SchemaInfoFilter filter = null)
+    {
+      return this.GetTableConstraintsAsync(this.CreateConnection(), filter);
+    }
+
+    public override async Task<List<TableConstraint>> GetTableConstraintsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      List<TableConstraint> constraints = new List<TableConstraint>();
+
+      List<DatabaseObject> dbObjects = await this.GetTableChildren(DatabaseObjectType.Constraint, dbConnection, filter);
+
+      foreach (var dbObject in dbObjects)
+      {
+        constraints.Add(dbObject as TableConstraint);
+      }
+
+      return constraints;
+    }
+    #endregion
+
+    #region Sequence
+    public override Task<List<Sequence>> GetSequencesAsync(SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<Sequence>("");
+    }
+
+    public override Task<List<Sequence>> GetSequencesAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<Sequence>(dbConnection, "");
+    }
+    #endregion
+
+    #region User Defined Type
+    public override Task<List<UserDefinedTypeAttribute>> GetUserDefinedTypeAttributesAsync(SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<UserDefinedTypeAttribute>("");
+    }
+
+    public override Task<List<UserDefinedTypeAttribute>> GetUserDefinedTypeAttributesAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<UserDefinedTypeAttribute>(dbConnection, "");
+    }
+    #endregion
+
+    #region Function
+    public override Task<List<Function>> GetFunctionsAsync(SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<Function>("");
+    }
+
+    public override Task<List<Function>> GetFunctionsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<Function>(dbConnection, "");
+    }
+    #endregion
+
+    #region Procedure
+    public override Task<List<Procedure>> GetProceduresAsync(SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<Procedure>("");
+    }
+
+    public override Task<List<Procedure>> GetProceduresAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<Procedure>(dbConnection, "");
+    }
+    #endregion
+
+    #region Routine Parameter
+    public override Task<List<RoutineParameter>> GetFunctionParametersAsync(SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<RoutineParameter>("");
+    }
+
+    public override Task<List<RoutineParameter>> GetFunctionParametersAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<RoutineParameter>(dbConnection, "");
+    }
+
+    public override Task<List<RoutineParameter>> GetProcedureParametersAsync(SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<RoutineParameter>("");
+    }
+
+    public override Task<List<RoutineParameter>> GetProcedureParametersAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+    {
+      return base.GetDbObjectsAsync<RoutineParameter>(dbConnection, "");
+    }
+    #endregion
+
+    #region Partition
+    public override Task<List<Table>> GetPartitionedTables(SchemaInfoFilter filter)
+    {
+      return base.GetDbObjectsAsync<Table>("");
+    }
+    public override Task<List<Table>> GetPartitionedTables(DbConnection dbConnection, SchemaInfoFilter filter)
+    {
+      return base.GetDbObjectsAsync<Table>("");
+    }
+    #endregion
+
+    #endregion
+
+    #region Dependency
+    #region View->Column Usage
+    public override Task<List<ViewColumnUsage>> GetViewColumnUsages(SchemaInfoFilter filter)
+    {
+      return base.GetDbObjectUsagesAsync<ViewColumnUsage>("");
+    }
+
+    public override Task<List<ViewColumnUsage>> GetViewColumnUsages(DbConnection dbConnection, SchemaInfoFilter filter)
+    {
+      return base.GetDbObjectUsagesAsync<ViewColumnUsage>(dbConnection, "");
+    }
+    #endregion
+
+    #region View->Table Usage
+    public override Task<List<ViewTableUsage>> GetViewTableUsages(SchemaInfoFilter filter, bool isFilterForReferenced = false)
+    {
+      return base.GetDbObjectUsagesAsync<ViewTableUsage>("");
+    }
+
+    public override Task<List<ViewTableUsage>> GetViewTableUsages(DbConnection dbConnection, SchemaInfoFilter filter, bool isFilterForReferenced = false)
+    {
+      return base.GetDbObjectUsagesAsync<ViewTableUsage>(dbConnection, "");
+    }
+    #endregion
+
+    #region Routine Script Usage
+    public override Task<List<RoutineScriptUsage>> GetRoutineScriptUsages(SchemaInfoFilter filter, bool isFilterForReferenced = false, bool includeViewTableUsages = false)
+    {
+      return base.GetDbObjectUsagesAsync<RoutineScriptUsage>("");
+    }
+
+    public override Task<List<RoutineScriptUsage>> GetRoutineScriptUsages(DbConnection dbConnection, SchemaInfoFilter filter, bool isFilterForReferenced = false, bool includeViewTableUsages = false)
+    {
+      return base.GetDbObjectUsagesAsync<RoutineScriptUsage>(dbConnection, "");
+    }
+    #endregion
+    #endregion
+
+    #region BulkCopy
+    public override Task BulkCopyAsync(DbConnection connection, DataTable dataTable, BulkCopyInfo bulkCopyInfo)
+    {
+      throw new NotImplementedException();
+    }
+    #endregion
+
+    #region Common Method
+    public override bool IsLowDbVersion(string serverVersion)
+    {
+      return this.IsLowDbVersion(serverVersion, "3");
+    }
+
+    public override DbConnector GetDbConnector()
+    {
+      return new DbConnector(new SqliteProvider(), new SqliteConnectionStringBuilder(), this.ConnectionInfo);
+    }
+
+    private List<List<string>> GetTableColumnDetails(string definition)
+    {
+      List<List<string>> columnDetails = new List<List<string>>();
+
+      int firstIndex = definition.IndexOf("(");
+      int lastIndex = definition.LastIndexOf(")", definition.Length - 1);
+
+      string innerContent = definition.Substring(firstIndex + 1, lastIndex - firstIndex - 1);
+
+      int singleQuotationCharCount = 0;
+      int leftParenthesisesCount = 0;
+      int rightParenthesisesCount = 0;
+
+      StringBuilder sb = new StringBuilder();
+
+      #region Extract Columns
+      List<string> columns = new List<string>();
+
+      for (int i = 0; i < innerContent.Length; i++)
+      {
+        var c = innerContent[i];
+
+        if (c == '\'')
         {
-            SqlBuilder sb = new SqlBuilder();
-
-            int i = 0;
-
-            foreach (var item in indexes)
-            {
-                if (i > 0)
-                {
-                    sb.Append("UNION ALL");
-                }
-
-                sb.Append($"SELECT '{item.Name}' AS Name, name AS ColumnName FROM PRAGMA_INDEX_INFO('{item.Name}')");
-
-                i++;
-            }
-
-            return sb.Content;
+          singleQuotationCharCount++;
         }
-        #endregion   
-
-        #region Constraint
-        public override Task<List<TableConstraint>> GetTableConstraintsAsync(SchemaInfoFilter filter = null)
+        else if (c == '(')
         {
-            return this.GetTableConstraintsAsync(this.CreateConnection(), filter);
+          leftParenthesisesCount++;
         }
-
-        public override async Task<List<TableConstraint>> GetTableConstraintsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
+        else if (c == ')')
         {
-            List<TableConstraint> constraints = new List<TableConstraint>();
-
-            List<DatabaseObject> dbObjects = await this.GetTableChildren(DatabaseObjectType.Constraint, dbConnection, filter);
-
-            foreach (var dbObject in dbObjects)
-            {
-                constraints.Add(dbObject as TableConstraint);
-            }
-
-            return constraints;
+          rightParenthesisesCount++;
         }
-        #endregion
-
-        #region Sequence
-        public override Task<List<Sequence>> GetSequencesAsync(SchemaInfoFilter filter = null)
+        else if (c == ',')
         {
-            return base.GetDbObjectsAsync<Sequence>("");
-        }
-
-        public override Task<List<Sequence>> GetSequencesAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<Sequence>(dbConnection, "");
-        }
-        #endregion
-
-        #region User Defined Type
-        public override Task<List<UserDefinedTypeAttribute>> GetUserDefinedTypeAttributesAsync(SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<UserDefinedTypeAttribute>("");
-        }
-
-        public override Task<List<UserDefinedTypeAttribute>> GetUserDefinedTypeAttributesAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<UserDefinedTypeAttribute>(dbConnection, "");
-        }
-        #endregion        
-
-        #region Function
-        public override Task<List<Function>> GetFunctionsAsync(SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<Function>("");
-        }
-
-        public override Task<List<Function>> GetFunctionsAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<Function>(dbConnection, "");
-        }
-        #endregion
-
-        #region Procedure
-        public override Task<List<Procedure>> GetProceduresAsync(SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<Procedure>("");
-        }
-
-        public override Task<List<Procedure>> GetProceduresAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<Procedure>(dbConnection, "");
-        }
-        #endregion     
-
-        #region Routine Parameter
-        public override Task<List<RoutineParameter>> GetFunctionParametersAsync(SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<RoutineParameter>("");
-        }
-
-        public override Task<List<RoutineParameter>> GetFunctionParametersAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<RoutineParameter>(dbConnection, "");
-        }
-
-        public override Task<List<RoutineParameter>> GetProcedureParametersAsync(SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<RoutineParameter>("");
-        }
-
-        public override Task<List<RoutineParameter>> GetProcedureParametersAsync(DbConnection dbConnection, SchemaInfoFilter filter = null)
-        {
-            return base.GetDbObjectsAsync<RoutineParameter>(dbConnection, "");
-        }
-        #endregion
-
-        #region Partition
-        public override Task<List<Table>> GetPartitionedTables(SchemaInfoFilter filter)
-        {
-            return base.GetDbObjectsAsync<Table>("");
-        }
-        public override Task<List<Table>> GetPartitionedTables(DbConnection dbConnection, SchemaInfoFilter filter)
-        {
-            return base.GetDbObjectsAsync<Table>("");
-        }
-        #endregion
-
-        #endregion
-
-        #region Dependency
-        #region View->Column Usage
-        public override Task<List<ViewColumnUsage>> GetViewColumnUsages(SchemaInfoFilter filter)
-        {
-            return base.GetDbObjectUsagesAsync<ViewColumnUsage>("");
-        }
-
-        public override Task<List<ViewColumnUsage>> GetViewColumnUsages(DbConnection dbConnection, SchemaInfoFilter filter)
-        {
-            return base.GetDbObjectUsagesAsync<ViewColumnUsage>(dbConnection, "");
-        }
-        #endregion
-
-        #region View->Table Usage
-        public override Task<List<ViewTableUsage>> GetViewTableUsages(SchemaInfoFilter filter, bool isFilterForReferenced = false)
-        {
-            return base.GetDbObjectUsagesAsync<ViewTableUsage>("");
-        }
-
-        public override Task<List<ViewTableUsage>> GetViewTableUsages(DbConnection dbConnection, SchemaInfoFilter filter, bool isFilterForReferenced = false)
-        {
-            return base.GetDbObjectUsagesAsync<ViewTableUsage>(dbConnection, "");
-        }
-        #endregion
-
-        #region Routine Script Usage
-        public override Task<List<RoutineScriptUsage>> GetRoutineScriptUsages(SchemaInfoFilter filter, bool isFilterForReferenced = false, bool includeViewTableUsages = false)
-        {
-            return base.GetDbObjectUsagesAsync<RoutineScriptUsage>("");
-        }
-
-        public override Task<List<RoutineScriptUsage>> GetRoutineScriptUsages(DbConnection dbConnection, SchemaInfoFilter filter, bool isFilterForReferenced = false, bool includeViewTableUsages = false)
-        {
-            return base.GetDbObjectUsagesAsync<RoutineScriptUsage>(dbConnection, "");
-        }
-        #endregion
-        #endregion
-
-        #region BulkCopy
-        public override Task BulkCopyAsync(DbConnection connection, DataTable dataTable, BulkCopyInfo bulkCopyInfo)
-        {
-            throw new NotImplementedException();
-        }
-        #endregion
-
-        #region Common Method
-        public override bool IsLowDbVersion(string serverVersion)
-        {
-            return this.IsLowDbVersion(serverVersion, "3");
-        }        
-
-        public override DbConnector GetDbConnector()
-        {
-            return new DbConnector(new SqliteProvider(), new SqliteConnectionStringBuilder(), this.ConnectionInfo);
-        }
-
-        private List<List<string>> GetTableColumnDetails(string definition)
-        {
-            List<List<string>> columnDetails = new List<List<string>>();
-
-            int firstIndex = definition.IndexOf("(");
-            int lastIndex = definition.LastIndexOf(")", definition.Length - 1);
-
-            string innerContent = definition.Substring(firstIndex + 1, lastIndex - firstIndex - 1);
-
-            int singleQuotationCharCount = 0;
-            int leftParenthesisesCount = 0;
-            int rightParenthesisesCount = 0;
-
-            StringBuilder sb = new StringBuilder();
-
-            #region Extract Columns
-            List<string> columns = new List<string>();
-
-            for (int i = 0; i < innerContent.Length; i++)
-            {
-                var c = innerContent[i];
-
-                if (c == '\'')
-                {
-                    singleQuotationCharCount++;
-                }
-                else if (c == '(')
-                {
-                    leftParenthesisesCount++;
-                }
-                else if (c == ')')
-                {
-                    rightParenthesisesCount++;
-                }
-                else if (c == ',')
-                {
-                    if (singleQuotationCharCount % 2 == 0 && leftParenthesisesCount == rightParenthesisesCount)
-                    {
-                        columns.Add(sb.ToString());
-                        sb.Clear();
-                        continue;
-                    }
-                }
-
-                sb.Append(c);
-            }
-
-            if (sb.Length > 0)
-            {
-                columns.Add(sb.ToString());
-            }
-            #endregion
-
+          if (singleQuotationCharCount % 2 == 0 && leftParenthesisesCount == rightParenthesisesCount)
+          {
+            columns.Add(sb.ToString());
             sb.Clear();
-
-            #region Parse Columns
-            foreach (string column in columns)
-            {
-                singleQuotationCharCount = 0;
-                leftParenthesisesCount = 0;
-                rightParenthesisesCount = 0;
-
-                List<string> columnItems = new List<string>();
-
-                foreach (var c in column)
-                {
-                    if (c == '\'')
-                    {
-                        singleQuotationCharCount++;
-                    }
-                    else if (c == '(')
-                    {
-                        leftParenthesisesCount++;
-                    }
-                    else if (c == ')')
-                    {
-                        rightParenthesisesCount++;
-                    }
-                    else if (c == ' ')
-                    {
-                        if (singleQuotationCharCount % 2 == 0 && leftParenthesisesCount == rightParenthesisesCount)
-                        {
-                            string item = sb.ToString().Trim();
-
-                            if (item.Length > 0)
-                            {
-                                columnItems.Add(item);
-                            }
-
-                            sb.Clear();
-                            continue;
-                        }
-                    }
-
-                    sb.Append(c);
-                }
-
-                if (sb.Length > 0)
-                {
-                    columnItems.Add(sb.ToString().Trim());
-                    sb.Clear();
-                }
-
-                columnDetails.Add(columnItems);
-            }
-            #endregion
-
-            sb.Clear();
-
-            return columnDetails;
+            continue;
+          }
         }
 
-        private string ExtractNameFromColumnDefintion(List<string> columnItems, DatabaseObjectType dbObjectType)
+        sb.Append(c);
+      }
+
+      if (sb.Length > 0)
+      {
+        columns.Add(sb.ToString());
+      }
+      #endregion
+
+      sb.Clear();
+
+      #region Parse Columns
+      foreach (string column in columns)
+      {
+        singleQuotationCharCount = 0;
+        leftParenthesisesCount = 0;
+        rightParenthesisesCount = 0;
+
+        List<string> columnItems = new List<string>();
+
+        foreach (var c in column)
         {
-            IEnumerable<int> indexes = this.FindAllIndexesInList(columnItems, "CONSTRAINT");
-
-            if (indexes.Count() > 0)
+          if (c == '\'')
+          {
+            singleQuotationCharCount++;
+          }
+          else if (c == '(')
+          {
+            leftParenthesisesCount++;
+          }
+          else if (c == ')')
+          {
+            rightParenthesisesCount++;
+          }
+          else if (c == ' ')
+          {
+            if (singleQuotationCharCount % 2 == 0 && leftParenthesisesCount == rightParenthesisesCount)
             {
-                bool matched = false;
-                int index = -1;
+              string item = sb.ToString().Trim();
 
-                if (dbObjectType == DatabaseObjectType.PrimaryKey && (index = this.FindIndexInList(columnItems, "PRIMARY")) > 0)
-                {
-                    matched = true;
-                }
-                else if (dbObjectType == DatabaseObjectType.ForeignKey && (index = this.FindIndexInList(columnItems, "REFERENCES")) > 0)
-                {
-                    matched = true;
-                }
-                else if (dbObjectType == DatabaseObjectType.Constraint && (index = this.FindIndexInList(columnItems, "CHECK")) > 0)
-                {
-                    matched = true;
-                }
-                else if (dbObjectType == DatabaseObjectType.Index && (index = this.FindIndexInList(columnItems, "UNIQUE")) > 0)
-                {
-                    matched = true;
-                }
+              if (item.Length > 0)
+              {
+                columnItems.Add(item);
+              }
 
-                if (matched)
-                {
-                    int closestConstraintIndex = indexes.Where(item => item < index).Max();
-
-                    return this.ExtractTableChildName(columnItems, closestConstraintIndex + 1);
-                }
+              sb.Clear();
+              continue;
             }
+          }
 
-            return string.Empty;
+          sb.Append(c);
         }
 
-        private List<string> ExtractColumnNamesFromTableConstraint(List<string> columnItems, int startIndex)
+        if (sb.Length > 0)
         {
-            List<string> columNames = new List<string>();
-
-            string item = columnItems[startIndex];
-
-            if (item.Contains("("))
-            {
-                int index = item.IndexOf("(");
-
-                columNames = item.Substring(index + 1).Trim().TrimEnd(')').Split(',').Select(item => item.Trim()).ToList();
-            }
-            else
-            {
-                item = columnItems.Skip(startIndex + 1).FirstOrDefault(item => item.Trim().StartsWith("("));
-
-                columNames = item.Trim().Trim('(', ')').Split(',').Select(item => item.Trim()).ToList();
-            }
-
-            return columNames;
+          columnItems.Add(sb.ToString().Trim());
+          sb.Clear();
         }
 
-        private string ExtractDefinitionFromTableConstraint(List<string> columnItems, int startIndex)
+        columnDetails.Add(columnItems);
+      }
+      #endregion
+
+      sb.Clear();
+
+      return columnDetails;
+    }
+
+    private string ExtractNameFromColumnDefintion(List<string> columnItems, DatabaseObjectType dbObjectType)
+    {
+      IEnumerable<int> indexes = this.FindAllIndexesInList(columnItems, "CONSTRAINT");
+
+      if (indexes.Count() > 0)
+      {
+        bool matched = false;
+        int index = -1;
+
+        if (dbObjectType == DatabaseObjectType.PrimaryKey && (index = this.FindIndexInList(columnItems, "PRIMARY")) > 0)
         {
-            string item = columnItems[startIndex];
-
-            if (item.Contains("("))
-            {
-                int index = item.IndexOf("(");
-
-                return item.Substring(index + 1);
-            }
-            else
-            {
-                return columnItems.Skip(startIndex + 1).FirstOrDefault(item => item.Trim().Length > 0);
-            }
+          matched = true;
+        }
+        else if (dbObjectType == DatabaseObjectType.ForeignKey && (index = this.FindIndexInList(columnItems, "REFERENCES")) > 0)
+        {
+          matched = true;
+        }
+        else if (dbObjectType == DatabaseObjectType.Constraint && (index = this.FindIndexInList(columnItems, "CHECK")) > 0)
+        {
+          matched = true;
+        }
+        else if (dbObjectType == DatabaseObjectType.Index && (index = this.FindIndexInList(columnItems, "UNIQUE")) > 0)
+        {
+          matched = true;
         }
 
-        private int FindIndexInList(List<string> list, string value)
+        if (matched)
         {
-            for (int i = 0; i < list.Count; i++)
-            {
-                string item = list[i].Trim().ToUpper();
+          int closestConstraintIndex = indexes.Where(item => item < index).Max();
 
-                if (item == value || item.StartsWith($"{value}("))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
+          return this.ExtractTableChildName(columnItems, closestConstraintIndex + 1);
         }
+      }
 
-        private IEnumerable<int> FindAllIndexesInList(List<string> list, string value)
+      return string.Empty;
+    }
+
+    private List<string> ExtractColumnNamesFromTableConstraint(List<string> columnItems, int startIndex)
+    {
+      List<string> columNames = new List<string>();
+
+      string item = columnItems[startIndex];
+
+      if (item.Contains("("))
+      {
+        int index = item.IndexOf("(");
+
+        columNames = item.Substring(index + 1).Trim().TrimEnd(')').Split(',').Select(item => item.Trim()).ToList();
+      }
+      else
+      {
+        item = columnItems.Skip(startIndex + 1).FirstOrDefault(item => item.Trim().StartsWith("("));
+
+        columNames = item.Trim().Trim('(', ')').Split(',').Select(item => item.Trim()).ToList();
+      }
+
+      return columNames;
+    }
+
+    private string ExtractDefinitionFromTableConstraint(List<string> columnItems, int startIndex)
+    {
+      string item = columnItems[startIndex];
+
+      if (item.Contains("("))
+      {
+        int index = item.IndexOf("(");
+
+        return item.Substring(index + 1);
+      }
+      else
+      {
+        return columnItems.Skip(startIndex + 1).FirstOrDefault(item => item.Trim().Length > 0);
+      }
+    }
+
+    private int FindIndexInList(List<string> list, string value)
+    {
+      for (int i = 0; i < list.Count; i++)
+      {
+        string item = list[i].Trim().ToUpper();
+
+        if (item == value || item.StartsWith($"{value}("))
         {
-            for (int i = 0; i < list.Count; i++)
-            {
-                string item = list[i].Trim().ToUpper();
-
-                if (item == value || item.StartsWith($"{value}("))
-                {
-                    yield return i;
-                }
-            }
+          return i;
         }
+      }
 
-        private string ExtractTableChildName(List<string> items, int startIndex)
+      return -1;
+    }
+
+    private IEnumerable<int> FindAllIndexesInList(List<string> list, string value)
+    {
+      for (int i = 0; i < list.Count; i++)
+      {
+        string item = list[i].Trim().ToUpper();
+
+        if (item == value || item.StartsWith($"{value}("))
         {
-            var keywords = KeywordManager.GetKeywords(this.DatabaseType);
-
-            return items.Skip(startIndex).FirstOrDefault(item => item.Length > 0 && !keywords.Contains(item));
+          yield return i;
         }
-        #endregion
+      }
+    }
 
-        #region Parse Column & DataType
-        public override string ParseColumn(Table table, TableColumn column)
+    private string ExtractTableChildName(List<string> items, int startIndex)
+    {
+      var keywords = KeywordManager.GetKeywords(this.DatabaseType);
+
+      return items.Skip(startIndex).FirstOrDefault(item => item.Length > 0 && !keywords.Contains(item));
+    }
+    #endregion
+
+    #region Parse Column & DataType
+    public override string ParseColumn(Table table, TableColumn column)
+    {
+      string dataType = this.ParseDataType(column);
+      string requiredClause = (column.IsRequired ? "NOT NULL" : "NULL");
+
+      if (column.IsComputed)
+      {
+        string generatedAlways = column.IsGeneratedAlways ? "GENERATED ALWAYS " : "";
+
+        return $"{this.GetQuotedString(column.Name)} {dataType} {generatedAlways}AS ({column.ComputeExp}) STORED {requiredClause}";
+      }
+      else
+      {
+        string identityClause = (this.Option.TableScriptsGenerateOption.GenerateIdentity && column.IsIdentity ? $"PRIMARY KEY AUTOINCREMENT" : "");
+        string defaultValueClause = this.Option.TableScriptsGenerateOption.GenerateDefaultValue && !string.IsNullOrEmpty(column.DefaultValue) && !ValueHelper.IsSequenceNextVal(column.DefaultValue) ? (" DEFAULT " + StringHelper.GetParenthesisedString(this.GetColumnDefaultValue(column))) : "";
+        string scriptComment = string.IsNullOrEmpty(column.ScriptComment) ? "" : $"/*{column.ScriptComment}*/";
+
+        return $"{this.GetQuotedString(column.Name)} {dataType} {identityClause} {requiredClause} {defaultValueClause} {scriptComment}";
+      }
+    }
+
+    public override string GetColumnDefaultValue(TableColumn column)
+    {
+      string defaultValue = base.GetColumnDefaultValue(column);
+
+      if (!string.IsNullOrEmpty(defaultValue))
+      {
+        string trimmed = defaultValue.Trim('(', ')').Trim();
+
+        if (trimmed.StartsWith("N'", StringComparison.OrdinalIgnoreCase) && trimmed.EndsWith("'"))
         {
-            string dataType = this.ParseDataType(column);
-            string requiredClause = (column.IsRequired ? "NOT NULL" : "NULL");
-
-            if (column.IsComputed)
-            {
-                string generatedAlways = column.IsGeneratedAlways ? "GENERATED ALWAYS " : "";
-
-                return $"{this.GetQuotedString(column.Name)} {dataType} {generatedAlways}AS ({column.ComputeExp}) STORED {requiredClause}";
-            }
-            else
-            {
-                string identityClause = (this.Option.TableScriptsGenerateOption.GenerateIdentity && column.IsIdentity ? $"PRIMARY KEY AUTOINCREMENT" : "");
-                string defaultValueClause = this.Option.TableScriptsGenerateOption.GenerateDefaultValue && !string.IsNullOrEmpty(column.DefaultValue) && !ValueHelper.IsSequenceNextVal(column.DefaultValue) ? (" DEFAULT " + StringHelper.GetParenthesisedString(this.GetColumnDefaultValue(column))) : "";
-                string scriptComment = string.IsNullOrEmpty(column.ScriptComment) ? "" : $"/*{column.ScriptComment}*/";
-
-                return $"{this.GetQuotedString(column.Name)} {dataType} {identityClause} {requiredClause} {defaultValueClause} {scriptComment}";
-            }
+          defaultValue = defaultValue.Replace(trimmed, trimmed.Substring(1));
         }
+      }
 
-        public override string ParseDataType(TableColumn column)
+      return defaultValue;
+    }
+
+    public override string ParseDataType(TableColumn column)
+    {
+      string dataLength = this.GetColumnDataLength(column);
+
+      if (!string.IsNullOrEmpty(dataLength))
+      {
+        dataLength = $"({dataLength})";
+      }
+
+      string dataType = $"{column.DataType}{dataLength}";
+
+      return dataType.Trim();
+    }
+
+    public override string GetColumnDataLength(TableColumn column)
+    {
+      string dataType = column.DataType;
+
+      DataTypeInfo dataTypeInfo = this.GetDataTypeInfo(dataType);
+
+      DataTypeSpecification dataTypeSpec = this.GetDataTypeSpecification(dataTypeInfo.DataType);
+
+      if (dataTypeSpec != null)
+      {
+        string args = dataTypeSpec.Args.ToLower().Trim();
+
+        if (string.IsNullOrEmpty(args))
         {
-            string dataLength = this.GetColumnDataLength(column);
-
-            if (!string.IsNullOrEmpty(dataLength))
-            {
-                dataLength = $"({dataLength})";
-            }
-
-            string dataType = $"{column.DataType}{dataLength}";
-
-            return dataType.Trim();
+          return string.Empty;
         }
-
-        public override string GetColumnDataLength(TableColumn column)
+        else if (args == "precision,scale")
         {
-            string dataType = column.DataType;
-
-            DataTypeInfo dataTypeInfo = this.GetDataTypeInfo(dataType);
-
-            DataTypeSpecification dataTypeSpec = this.GetDataTypeSpecification(dataTypeInfo.DataType);
-
-            if (dataTypeSpec != null)
-            {
-                string args = dataTypeSpec.Args.ToLower().Trim();
-
-                if (string.IsNullOrEmpty(args))
-                {
-                    return string.Empty;
-                }
-                else if (args == "precision,scale")
-                {
-                    if (dataTypeInfo.Args != null && !dataTypeInfo.Args.Contains(","))
-                    {
-                        return $"{column.Precision ?? 0},{column.Scale ?? 0}";
-                    }
-                    else if (column.Precision.HasValue && column.Scale.HasValue)
-                    {
-                        return $"{column.Precision},{column.Scale}";
-                    }
-                }
-            }
-
-            return string.Empty;
+          if (dataTypeInfo.Args != null && !dataTypeInfo.Args.Contains(","))
+          {
+            return $"{column.Precision ?? 0},{column.Scale ?? 0}";
+          }
+          else if (column.Precision.HasValue && column.Scale.HasValue)
+          {
+            return $"{column.Precision},{column.Scale}";
+          }
         }
-        #endregion
+      }
 
-        #region Sql Query Clause
-        protected override string GetSqlForPagination(string tableName, string columnNames, string orderColumns, string whereClause, long pageNumber, int pageSize)
-        {
-            var startEndRowNumber = PaginationHelper.GetStartEndRowNumber(pageNumber, pageSize);
+      return string.Empty;
+    }
+    #endregion
 
-            string orderByColumns = (!string.IsNullOrEmpty(orderColumns) ? orderColumns : this.GetDefaultOrder());
+    #region Sql Query Clause
+    protected override string GetSqlForPagination(string tableName, string columnNames, string orderColumns, string whereClause, long pageNumber, int pageSize)
+    {
+      var startEndRowNumber = PaginationHelper.GetStartEndRowNumber(pageNumber, pageSize);
 
-            string orderBy = !string.IsNullOrEmpty(orderByColumns) ? $" ORDER BY {orderByColumns}" : "";
+      string orderByColumns = (!string.IsNullOrEmpty(orderColumns) ? orderColumns : this.GetDefaultOrder());
 
-            SqlBuilder sb = new SqlBuilder();
+      string orderBy = !string.IsNullOrEmpty(orderByColumns) ? $" ORDER BY {orderByColumns}" : "";
 
-            sb.Append($@"SELECT {columnNames}
+      SqlBuilder sb = new SqlBuilder();
+
+      sb.Append($@"SELECT {columnNames}
 							  FROM {tableName}
                              {whereClause} 
                              {orderBy}
                              LIMIT {pageSize} OFFSET {startEndRowNumber.StartRowNumber - 1}");
 
-            return sb.Content;
-        }
-        #endregion
+      return sb.Content;
     }
+    #endregion
+  }
 }

--- a/DatabaseInterpreter/DatabaseInterpreter.Core/Interpreter/SqliteInterpreter.cs
+++ b/DatabaseInterpreter/DatabaseInterpreter.Core/Interpreter/SqliteInterpreter.cs
@@ -1094,23 +1094,106 @@ namespace DatabaseInterpreter.Core
       }
     }
 
+    //public override string GetColumnDefaultValue(TableColumn column)
+    //{
+    //  string defaultValue = base.GetColumnDefaultValue(column);
+
+    //  if (!string.IsNullOrEmpty(defaultValue))
+    //  {
+    //    string trimmed = defaultValue.Trim('(', ')').Trim();
+
+    //    if (trimmed.StartsWith("N'", StringComparison.OrdinalIgnoreCase) && trimmed.EndsWith("'"))
+    //    {
+    //      defaultValue = defaultValue.Replace(trimmed, trimmed.Substring(1));
+    //    }
+    //  }
+
+    //  return defaultValue;
+    //}
+
+
     public override string GetColumnDefaultValue(TableColumn column)
     {
-      string defaultValue = base.GetColumnDefaultValue(column);
+      string defaultValue = column.DefaultValue?.Trim();
 
-      if (!string.IsNullOrEmpty(defaultValue))
+      if (string.IsNullOrEmpty(defaultValue))
       {
-        string trimmed = defaultValue.Trim('(', ')').Trim();
+        return defaultValue;
+      }
 
-        if (trimmed.StartsWith("N'", StringComparison.OrdinalIgnoreCase) && trimmed.EndsWith("'"))
+      string trimmed = defaultValue.Trim('(', ')').Trim();
+
+      if (trimmed.StartsWith("N'", StringComparison.OrdinalIgnoreCase) && trimmed.EndsWith("'"))
+      {
+        defaultValue = defaultValue.Replace(trimmed, trimmed.Substring(1));
+      }
+
+      string sqliteDefaultExpression = this.GetSqliteDefaultExpression(defaultValue);
+
+      if (!string.IsNullOrEmpty(sqliteDefaultExpression))
+      {
+        return sqliteDefaultExpression;
+      }
+
+      if (DataTypeHelper.IsCharType(column.DataType, this.DatabaseType))
+      {
+        string trimmedValue = defaultValue.Trim('(', ')').Trim();
+
+        if (!trimmedValue.StartsWith('\'') && !trimmedValue.StartsWith("N'", StringComparison.OrdinalIgnoreCase))
         {
-          defaultValue = defaultValue.Replace(trimmed, trimmed.Substring(1));
+          return $"'{defaultValue}'";
         }
       }
 
       return defaultValue;
     }
 
+    private string GetSqliteDefaultExpression(string value)
+    {
+      if (string.IsNullOrWhiteSpace(value))
+      {
+        return null;
+      }
+
+      string trimmed = value.Trim();
+
+      if (this.IsSqliteDefaultExpression(trimmed))
+      {
+        return trimmed;
+      }
+
+      if (trimmed.Length >= 2 && trimmed[0] == '\'' && trimmed[^1] == '\'')
+      {
+        string inner = trimmed.Substring(1, trimmed.Length - 2).Trim();
+
+        if (this.IsSqliteDefaultExpression(inner))
+        {
+          return inner;
+        }
+      }
+
+      return null;
+    }
+
+    private bool IsSqliteDefaultExpression(string value)
+    {
+      if (string.IsNullOrWhiteSpace(value))
+      {
+        return false;
+      }
+
+      string normalized = StringHelper.GetBalanceParenthesisTrimedValue(value.Trim());
+
+      return normalized.Equals("CURRENT_TIMESTAMP", StringComparison.OrdinalIgnoreCase)
+        || normalized.Equals("CURRENT_DATE", StringComparison.OrdinalIgnoreCase)
+        || normalized.Equals("CURRENT_TIME", StringComparison.OrdinalIgnoreCase)
+        || normalized.StartsWith("DATETIME(", StringComparison.OrdinalIgnoreCase)
+        || normalized.StartsWith("DATE(", StringComparison.OrdinalIgnoreCase)
+        || normalized.StartsWith("TIME(", StringComparison.OrdinalIgnoreCase)
+        || normalized.StartsWith("STRFTIME(", StringComparison.OrdinalIgnoreCase)
+        || normalized.StartsWith("JULIANDAY(", StringComparison.OrdinalIgnoreCase)
+        || normalized.StartsWith("UNIXEPOCH(", StringComparison.OrdinalIgnoreCase);
+    }
     public override string ParseDataType(TableColumn column)
     {
       string dataLength = this.GetColumnDataLength(column);

--- a/DatabaseInterpreter/DatabaseInterpreter.Core/Interpreter/SqliteInterpreter.cs
+++ b/DatabaseInterpreter/DatabaseInterpreter.Core/Interpreter/SqliteInterpreter.cs
@@ -13,6 +13,12 @@ namespace DatabaseInterpreter.Core
 {
   public class SqliteInterpreter : DbInterpreter
   {
+    /// <summary>
+    /// SQLite default SQLITE_MAX_COMPOUND_SELECT is 500.
+    /// Stay safely below with batches of 400.
+    /// </summary>
+    private const int MaxCompoundSelectTerms = 400;
+
     #region Field & Property
     public override string CommentString => "--";
     public override string CommandParameterChar => "@";
@@ -204,10 +210,7 @@ namespace DatabaseInterpreter.Core
 
       if (filter?.TableNames == null)
       {
-        if (filter == null)
-        {
-          filter = new SchemaInfoFilter();
-        }
+        filter ??= new SchemaInfoFilter();
 
         if (!isForView)
         {
@@ -219,7 +222,13 @@ namespace DatabaseInterpreter.Core
         }
       }
 
-      var columns = await base.GetDbObjectsAsync<TableColumn>(dbConnection, this.GetSqlForTableColumns(filter));
+      // Batch to avoid "too many terms in compound SELECT"
+      var columns = new List<TableColumn>();
+
+      foreach (string[] batch in filter.TableNames.Chunk(MaxCompoundSelectTerms))
+      {
+        columns.AddRange(await base.GetDbObjectsAsync<TableColumn>(dbConnection, this.GetSqlForTableColumns(batch)));
+      }
 
       #region Get generated column expression
       var tablesSql = this.GetSqlForTableViews(DatabaseObjectType.Table, filter, true);
@@ -247,13 +256,16 @@ namespace DatabaseInterpreter.Core
               {
                 string item = cd[i];
 
-                if (item.ToUpper() == "GENERATED")
+                if (item.Equals("GENERATED", StringComparison.OrdinalIgnoreCase))
                 {
                   tableColumn.IsGeneratedAlways = true;
-                  tableColumn.ComputeExp = cd.Skip(i + 1).Where(item => item.ToUpper() != "ALWAYS" && item.ToUpper() != "AS").FirstOrDefault();
+                  tableColumn.ComputeExp = cd.Skip(i + 1)
+                    .Where(item => !item.Equals("ALWAYS", StringComparison.OrdinalIgnoreCase)
+                                && !item.Equals("AS", StringComparison.OrdinalIgnoreCase))
+                    .FirstOrDefault();
                   break;
                 }
-                else if (item.ToUpper() == "AS")
+                else if (item.Equals("AS", StringComparison.OrdinalIgnoreCase))
                 {
                   tableColumn.ComputeExp = cd.Skip(i + 1).FirstOrDefault();
                 }
@@ -269,18 +281,16 @@ namespace DatabaseInterpreter.Core
       return columns;
     }
 
-    private string GetSqlForTableColumns(SchemaInfoFilter filter = null)
+    private string GetSqlForTableColumns(IEnumerable<string> tableNames)
     {
       SqlBuilder sb = new SqlBuilder();
 
-      string[] tableNames = filter?.TableNames;
-
       if (tableNames != null)
       {
-        for (int i = 0; i < tableNames.Length; i++)
-        {
-          string tableName = tableNames[i];
+        int i = 0;
 
+        foreach (string tableName in tableNames)
+        {
           if (i > 0)
           {
             sb.Append("UNION ALL");
@@ -294,6 +304,8 @@ namespace DatabaseInterpreter.Core
                                 CASE WHEN ""notnull""=1 THEN 0 ELSE 1 END AS IsNullable,
                                 dflt_value AS DefaultValue, pk AS IsPrimaryKey, cid AS ""Order""
                                 FROM PRAGMA_TABLE_XINFO('{tableName}')");
+
+          i++;
         }
       }
 
@@ -311,33 +323,59 @@ namespace DatabaseInterpreter.Core
     {
       if (filter?.TableNames == null)
       {
-        if (filter == null)
-        {
-          filter = new SchemaInfoFilter();
-        }
-
-        filter.TableNames = (await this.GetTableNamesAsync());
+        filter ??= new SchemaInfoFilter();
+        filter.TableNames = await this.GetTableNamesAsync();
       }
 
-      List<TablePrimaryKeyItem> primaryKeyItems = await base.GetDbObjectsAsync<TablePrimaryKeyItem>(dbConnection, this.GetSqlForPrimaryKeys(filter));
+      // Batch to avoid "too many terms in compound SELECT"
+      List<TablePrimaryKeyItem> primaryKeyItems = new List<TablePrimaryKeyItem>();
+
+      foreach (string[] batch in filter.TableNames.Chunk(MaxCompoundSelectTerms))
+      {
+        primaryKeyItems.AddRange(await base.GetDbObjectsAsync<TablePrimaryKeyItem>(dbConnection, this.GetSqlForPrimaryKeys(batch)));
+      }
 
       await this.MakeupTableChildrenNames(primaryKeyItems, filter);
 
       return primaryKeyItems;
     }
-
-    private string GetSqlForPrimaryKeys(SchemaInfoFilter filter = null)
+    private string GetSqlForForeignKeys(IEnumerable<string> tableNames, bool isFilterForReferenced = false)
     {
       SqlBuilder sb = new SqlBuilder();
 
-      string[] tableNames = filter?.TableNames;
+      if (!isFilterForReferenced && tableNames != null)
+      {
+        int i = 0;
+
+        foreach (string tableName in tableNames)
+        {
+          if (i > 0)
+          {
+            sb.Append("UNION ALL");
+          }
+
+          sb.Append($@"SELECT ""table"" AS ReferencedTableName, ""to"" AS ReferencedColumnName,
+                                '{tableName}' AS TableName, ""from"" AS ColumnName,
+                                CASE WHEN on_update='CASCADE' THEN 1 ELSE 0 END AS UpdateCascade,
+                                CASE WHEN on_delete='CASCADE' THEN 1 ELSE 0 END AS DeleteCascade
+                                FROM PRAGMA_foreign_key_list('{tableName}')");
+
+          i++;
+        }
+      }
+
+      return sb.Content;
+    }
+    private string GetSqlForPrimaryKeys(IEnumerable<string> tableNames)
+    {
+      SqlBuilder sb = new SqlBuilder();
 
       if (tableNames != null)
       {
-        for (int i = 0; i < tableNames.Length; i++)
-        {
-          string tableName = tableNames[i];
+        int i = 0;
 
+        foreach (string tableName in tableNames)
+        {
           if (i > 0)
           {
             sb.Append("UNION ALL");
@@ -346,11 +384,39 @@ namespace DatabaseInterpreter.Core
           sb.Append($@"SELECT '{tableName}' as TableName, name AS ColumnName
                         FROM PRAGMA_TABLE_XINFO('{tableName}')
                         WHERE pk>0");
+
+          i++;
         }
       }
 
       return sb.Content;
     }
+
+    //private string GetSqlForPrimaryKeys(SchemaInfoFilter filter = null)
+    //{
+    //  SqlBuilder sb = new SqlBuilder();
+
+    //  string[] tableNames = filter?.TableNames;
+
+    //  if (tableNames != null)
+    //  {
+    //    for (int i = 0; i < tableNames.Length; i++)
+    //    {
+    //      string tableName = tableNames[i];
+
+    //      if (i > 0)
+    //      {
+    //        sb.Append("UNION ALL");
+    //      }
+
+    //      sb.Append($@"SELECT '{tableName}' as TableName, name AS ColumnName
+    //                    FROM PRAGMA_TABLE_XINFO('{tableName}')
+    //                    WHERE pk>0");
+    //    }
+    //  }
+
+    //  return sb.Content;
+    //}
 
     private async Task MakeupTableChildrenNames(IEnumerable<TableColumnChild> columnChildren, SchemaInfoFilter filter = null)
     {
@@ -401,7 +467,7 @@ namespace DatabaseInterpreter.Core
                 flag = "PRIMARY";
               }
 
-              if (flag != null && items.Any(item => item.ToUpper() == flag))
+              if (flag != null && items.Any(item => item.Equals(flag, StringComparison.OrdinalIgnoreCase)))
               {
                 for (int i = 0; i < items.Count; i++)
                 {
@@ -416,7 +482,7 @@ namespace DatabaseInterpreter.Core
                   {
                     var columnNames = item.Trim('(', ')').Split(',').Select(item => item.Trim());
 
-                    if (columnNames.Any(item => item.ToLower() == columnName.ToLower()))
+                    if (columnNames.Any(item => item.Equals(columnName, StringComparison.OrdinalIgnoreCase)))
                     {
                       cc.Name = name;
                       break;
@@ -539,15 +605,16 @@ namespace DatabaseInterpreter.Core
     {
       if (filter?.TableNames == null)
       {
-        if (filter == null)
-        {
-          filter = new SchemaInfoFilter();
-        }
-
         filter = new SchemaInfoFilter() { TableNames = await GetTableNamesAsync() };
       }
 
-      List<TableForeignKeyItem> foreignKeyItems = await base.GetDbObjectsAsync<TableForeignKeyItem>(dbConnection, this.GetSqlForForeignKeys(filter, isFilterForReferenced));
+      // Batch to avoid "too many terms in compound SELECT"
+      List<TableForeignKeyItem> foreignKeyItems = new List<TableForeignKeyItem>();
+
+      foreach (string[] batch in filter.TableNames.Chunk(MaxCompoundSelectTerms))
+      {
+        foreignKeyItems.AddRange(await base.GetDbObjectsAsync<TableForeignKeyItem>(dbConnection, this.GetSqlForForeignKeys(batch, isFilterForReferenced)));
+      }
 
       await this.MakeupTableChildrenNames(foreignKeyItems, filter);
 
@@ -568,31 +635,59 @@ namespace DatabaseInterpreter.Core
       return tables.Select(item => item.Name).ToArray();
     }
 
-    private string GetSqlForForeignKeys(SchemaInfoFilter filter = null, bool isFilterForReferenced = false)
+    //private string GetSqlForForeignKeys(SchemaInfoFilter filter = null, bool isFilterForReferenced = false)
+    //{
+    //  SqlBuilder sb = new SqlBuilder();
+
+    //  if (!isFilterForReferenced)
+    //  {
+    //    string[] tableNames = filter?.TableNames;
+
+    //    if (tableNames != null)
+    //    {
+    //      for (int i = 0; i < tableNames.Length; i++)
+    //      {
+    //        string tableName = tableNames[i];
+
+    //        if (i > 0)
+    //        {
+    //          sb.Append("UNION ALL");
+    //        }
+
+    //        sb.Append($@"SELECT ""table"" AS ReferencedTableName, ""to"" AS ReferencedColumnName,
+    //                            '{tableName}' AS TableName, ""from"" AS ColumnName,
+    //                            CASE WHEN on_update='CASCADE' THEN 1 ELSE 0 END AS UpdateCascade,
+    //                            CASE WHEN on_delete='CASCADE' THEN 1 ELSE 0 END AS DeleteCascade
+    //                            FROM PRAGMA_foreign_key_list('{tableName}')");
+    //      }
+    //    }
+    //  }
+
+    //  return sb.Content;
+    //}
+
+    private string GetSqlForForeignKeys(string[] tableNames, bool isFilterForReferenced = false)
     {
       SqlBuilder sb = new SqlBuilder();
 
-      if (!isFilterForReferenced)
+      if (!isFilterForReferenced && tableNames != null)
       {
-        string[] tableNames = filter?.TableNames;
+        int i = 0;
 
-        if (tableNames != null)
+        foreach (string tableName in tableNames)
         {
-          for (int i = 0; i < tableNames.Length; i++)
+          if (i > 0)
           {
-            string tableName = tableNames[i];
+            sb.Append("UNION ALL");
+          }
 
-            if (i > 0)
-            {
-              sb.Append("UNION ALL");
-            }
-
-            sb.Append($@"SELECT ""table"" AS ReferencedTableName, ""to"" AS ReferencedColumnName,
+          sb.Append($@"SELECT ""table"" AS ReferencedTableName, ""to"" AS ReferencedColumnName,
                                 '{tableName}' AS TableName, ""from"" AS ColumnName,
                                 CASE WHEN on_update='CASCADE' THEN 1 ELSE 0 END AS UpdateCascade,
                                 CASE WHEN on_delete='CASCADE' THEN 1 ELSE 0 END AS DeleteCascade
                                 FROM PRAGMA_foreign_key_list('{tableName}')");
-          }
+
+          i++;
         }
       }
 
@@ -627,7 +722,13 @@ namespace DatabaseInterpreter.Core
 
       List<TableIndexItem> items = new List<TableIndexItem>();
 
-      var indexColumns = await base.GetDbObjectsAsync<TableIndexItem>(this.GetSqlForIndexColumns(indexes));
+      // Batch to avoid "too many terms in compound SELECT"
+      var indexColumns = new List<TableIndexItem>();
+
+      foreach (var batch in indexes.Chunk(MaxCompoundSelectTerms))
+      {
+        indexColumns.AddRange(await base.GetDbObjectsAsync<TableIndexItem>(this.GetSqlForIndexColumns(batch)));
+      }
 
       foreach (var ic in indexColumns)
       {
@@ -667,7 +768,7 @@ namespace DatabaseInterpreter.Core
       return this.GetSqlForTableChildren(DatabaseObjectType.Index, filter);
     }
 
-    private string GetSqlForIndexColumns(List<TableIndex> indexes)
+    private string GetSqlForIndexColumns(IEnumerable<TableIndex> indexes)
     {
       SqlBuilder sb = new SqlBuilder();
 


### PR DESCRIPTION

1.	SQLite Error 1: 'too many terms in compound SELECT' — When the source database has more than ~500 tables, the UNION ALL queries built for columns, primary keys, foreign keys, and index columns exceed SQLite's SQLITE_MAX_COMPOUND_SELECT limit (default 500).
2.	SQLite Error 1: 'near "-": syntax error' — Index names containing special characters (e.g., UQ_Chat_OnlineUser_SiteID-ChatUserID) were emitted unquoted because SupportQuotationChar was set to false, causing the hyphen to be parsed as a minus operator.
3.	SQLite Error 1: 'near "NOW": syntax error' — Default value expressions like DATETIME('NOW','LOCALTIME') were incorrectly wrapped in string quotes ('...'), turning a valid SQLite function call into an invalid string literal.

Testing
•	Verified conversion of a 1163-table SQL Server database to SQLite completes without errors.
•	Confirmed index names with hyphens and other special characters are properly quoted.
•	Confirmed DATETIME('NOW','LOCALTIME') default values are emitted as expressions, not strings.